### PR TITLE
feat: [utils] add toPTR and ToPTRSlice funcs

### DIFF
--- a/.changelog/11.txt
+++ b/.changelog/11.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+`utils` - Add new functions `ToPTR` and ToPTRSlice` to convert a value to a pointer and a slice of pointers respectively. This is useful for creating slices of pointers to values without needing to manually create each pointer.
+```

--- a/utils/doc.go
+++ b/utils/doc.go
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+/*
+Package utils is a utility package.
+
+# Pointers
+
+Utility provides functions to convert values to pointers.
+
+  - [ToPTR] is a generic function that takes a value and returns a pointer to it.
+  - [ToPTRSlice] is a generic function that takes a slice of values and returns a slice of pointers to them.
+*/
+package utils

--- a/utils/go.mod
+++ b/utils/go.mod
@@ -1,3 +1,11 @@
 module github.com/orange-cloudavenue/common-go/utils
 
 go 1.20
+
+require github.com/stretchr/testify v1.10.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/utils/go.sum
+++ b/utils/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/utils/to_ptr.go
+++ b/utils/to_ptr.go
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package utils
+
+// ToPTR is a generic function that takes a value and returns a pointer to it.
+func ToPTR[T any](v T) *T {
+	return &v
+}
+
+// ToPTRSlice is a generic function that takes a slice of values and returns a slice of pointers to them.
+func ToPTRSlice[T any](v []T) []*T {
+	if len(v) == 0 {
+		return nil
+	}
+
+	slicePointer := make([]*T, len(v))
+	for i, item := range v {
+		// FIX variable into the local variable for bypassing the pointer aliasing (https://stackoverflow.com/a/64715804)
+		item := item //nolint:copyloopvar
+		slicePointer[i] = &item
+	}
+	return slicePointer
+}

--- a/utils/to_ptr_test.go
+++ b/utils/to_ptr_test.go
@@ -10,6 +10,7 @@
 package utils
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -20,39 +21,43 @@ func ExampleToPTR() {
 	// Example usage of ToPTR function
 	str := "Hello, World!"
 	ptr := ToPTR(str)
-	println(reflect.TypeOf(ptr).Kind()) // Output: reflect.Ptr
+	fmt.Println(reflect.TypeOf(ptr).Kind().String()) // Output: ptr
 }
 
 func TestToPTR(t *testing.T) {
 	t.Parallel()
 
 	t.Run("int", func(t *testing.T) {
+		t.Parallel()
 		val := 42
-		ptr := utils.ToPTR(val)
+		ptr := ToPTR(val)
 		assert.NotNil(t, ptr)
 		assert.Equal(t, val, *ptr)
 	})
 
 	t.Run("string", func(t *testing.T) {
+		t.Parallel()
 		val := "hello"
-		ptr := utils.ToPTR(val)
+		ptr := ToPTR(val)
 		assert.NotNil(t, ptr)
 		assert.Equal(t, val, *ptr)
 	})
 
 	t.Run("struct", func(t *testing.T) {
+		t.Parallel()
 		type Sample struct {
 			Field string
 		}
 		val := Sample{Field: "test"}
-		ptr := utils.ToPTR(val)
+		ptr := ToPTR(val)
 		assert.NotNil(t, ptr)
 		assert.Equal(t, val, *ptr)
 	})
 
 	t.Run("nilable type", func(t *testing.T) {
+		t.Parallel()
 		var val *int
-		ptr := utils.ToPTR(val)
+		ptr := ToPTR(val)
 		assert.NotNil(t, ptr)
 		assert.Equal(t, val, *ptr)
 	})
@@ -63,7 +68,10 @@ func ExampleToPTRSlice() {
 	strs := []string{"Hello", "World"}
 	ptrs := ToPTRSlice(strs)
 	for _, ptr := range ptrs {
-		println(reflect.TypeOf(ptr).Kind()) // Output: reflect.Ptr
+		fmt.Println(reflect.TypeOf(ptr).Kind().String())
+		// Output:
+		// ptr
+		// ptr
 	}
 }
 
@@ -71,6 +79,7 @@ func TestToPTRSlice(t *testing.T) {
 	t.Parallel()
 
 	t.Run("int slice", func(t *testing.T) {
+		t.Parallel()
 		vals := []int{1, 2, 3}
 		ptrs := ToPTRSlice(vals)
 		assert.NotNil(t, ptrs)
@@ -82,6 +91,7 @@ func TestToPTRSlice(t *testing.T) {
 	})
 
 	t.Run("string slice", func(t *testing.T) {
+		t.Parallel()
 		vals := []string{"a", "b", "c"}
 		ptrs := ToPTRSlice(vals)
 		assert.NotNil(t, ptrs)
@@ -93,6 +103,7 @@ func TestToPTRSlice(t *testing.T) {
 	})
 
 	t.Run("struct slice", func(t *testing.T) {
+		t.Parallel()
 		type Sample struct {
 			Field string
 		}
@@ -107,12 +118,14 @@ func TestToPTRSlice(t *testing.T) {
 	})
 
 	t.Run("empty slice", func(t *testing.T) {
+		t.Parallel()
 		vals := []int{}
 		ptrs := ToPTRSlice(vals)
 		assert.Nil(t, ptrs)
 	})
 
 	t.Run("nil slice", func(t *testing.T) {
+		t.Parallel()
 		var vals []int
 		ptrs := ToPTRSlice(vals)
 		assert.Nil(t, ptrs)

--- a/utils/to_ptr_test.go
+++ b/utils/to_ptr_test.go
@@ -1,0 +1,120 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package utils
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func ExampleToPTR() {
+	// Example usage of ToPTR function
+	str := "Hello, World!"
+	ptr := ToPTR(str)
+	println(reflect.TypeOf(ptr).Kind()) // Output: reflect.Ptr
+}
+
+func TestToPTR(t *testing.T) {
+	t.Parallel()
+
+	t.Run("int", func(t *testing.T) {
+		val := 42
+		ptr := utils.ToPTR(val)
+		assert.NotNil(t, ptr)
+		assert.Equal(t, val, *ptr)
+	})
+
+	t.Run("string", func(t *testing.T) {
+		val := "hello"
+		ptr := utils.ToPTR(val)
+		assert.NotNil(t, ptr)
+		assert.Equal(t, val, *ptr)
+	})
+
+	t.Run("struct", func(t *testing.T) {
+		type Sample struct {
+			Field string
+		}
+		val := Sample{Field: "test"}
+		ptr := utils.ToPTR(val)
+		assert.NotNil(t, ptr)
+		assert.Equal(t, val, *ptr)
+	})
+
+	t.Run("nilable type", func(t *testing.T) {
+		var val *int
+		ptr := utils.ToPTR(val)
+		assert.NotNil(t, ptr)
+		assert.Equal(t, val, *ptr)
+	})
+}
+
+func ExampleToPTRSlice() {
+	// Example usage of ToPTRSlice function
+	strs := []string{"Hello", "World"}
+	ptrs := ToPTRSlice(strs)
+	for _, ptr := range ptrs {
+		println(reflect.TypeOf(ptr).Kind()) // Output: reflect.Ptr
+	}
+}
+
+func TestToPTRSlice(t *testing.T) {
+	t.Parallel()
+
+	t.Run("int slice", func(t *testing.T) {
+		vals := []int{1, 2, 3}
+		ptrs := ToPTRSlice(vals)
+		assert.NotNil(t, ptrs)
+		assert.Equal(t, len(vals), len(ptrs))
+		for i, ptr := range ptrs {
+			assert.NotNil(t, ptr)
+			assert.Equal(t, vals[i], *ptr)
+		}
+	})
+
+	t.Run("string slice", func(t *testing.T) {
+		vals := []string{"a", "b", "c"}
+		ptrs := ToPTRSlice(vals)
+		assert.NotNil(t, ptrs)
+		assert.Equal(t, len(vals), len(ptrs))
+		for i, ptr := range ptrs {
+			assert.NotNil(t, ptr)
+			assert.Equal(t, vals[i], *ptr)
+		}
+	})
+
+	t.Run("struct slice", func(t *testing.T) {
+		type Sample struct {
+			Field string
+		}
+		vals := []Sample{{Field: "x"}, {Field: "y"}}
+		ptrs := ToPTRSlice(vals)
+		assert.NotNil(t, ptrs)
+		assert.Equal(t, len(vals), len(ptrs))
+		for i, ptr := range ptrs {
+			assert.NotNil(t, ptr)
+			assert.Equal(t, vals[i], *ptr)
+		}
+	})
+
+	t.Run("empty slice", func(t *testing.T) {
+		vals := []int{}
+		ptrs := ToPTRSlice(vals)
+		assert.Nil(t, ptrs)
+	})
+
+	t.Run("nil slice", func(t *testing.T) {
+		var vals []int
+		ptrs := ToPTRSlice(vals)
+		assert.Nil(t, ptrs)
+	})
+}


### PR DESCRIPTION
This pull request introduces a new utility package, `utils`, which provides generic functions for handling pointers and includes comprehensive documentation, implementation, and tests. The most significant changes include adding the `ToPTR` and `ToPTRSlice` functions, extensive test coverage, and the inclusion of licensing information.

### New Utility Functions:
* Added `ToPTR`, a generic function to convert a value into a pointer.
* Added `ToPTRSlice`, a generic function to convert a slice of values into a slice of pointers.

### Testing:
* Implemented unit tests for `ToPTR` and `ToPTRSlice`, covering various data types, including primitives, structs, and edge cases like empty or nil slices.
* Added example usage functions for `ToPTR` and `ToPTRSlice` to demonstrate their functionality.

### Documentation:
* Added package-level documentation in `utils/doc.go`, explaining the purpose of the `utils` package and its exported functions.

### Licensing:
* Included SPDX license headers in all source files, specifying the Mozilla Public License 2.0. [[1]](diffhunk://#diff-d60331d289f4ffded786e9189a86468501ba11c60f87678fb445004e94f71114R1-R20) [[2]](diffhunk://#diff-3fd26d5699b01e46a8032e59af28448d78a140a1244c53a9bf1297950d8f0c52R1-R30) [[3]](diffhunk://#diff-2e8ac06860897e82632094c53b52afc3563cc084aa7774de012fcb06e9044103R1-R120)

### Dependency Management:
* Updated `go.mod` to include necessary dependencies for testing, such as `github.com/stretchr/testify`.